### PR TITLE
fix: event validation

### DIFF
--- a/src/Fluss.Testing/AggregateTestBed.cs
+++ b/src/Fluss.Testing/AggregateTestBed.cs
@@ -18,7 +18,7 @@ public class AggregateTestBed<TAggregate, TKey> : EventTestBed where TAggregate 
     {
         var validator = new Mock<IRootValidator>();
         validator.Setup(v => v.ValidateEvent(It.IsAny<EventEnvelope>(), It.IsAny<IReadOnlyList<EventEnvelope>?>()))
-            .Returns<EventEnvelope>(_ => Task.CompletedTask);
+            .Returns<EventEnvelope, IReadOnlyList<EventEnvelope>?>((_, _) => Task.CompletedTask);
         validator.Setup(v => v.ValidateAggregate(It.IsAny<AggregateRoot>(), It.IsAny<UnitOfWork.UnitOfWork>()))
             .Returns<AggregateRoot, UnitOfWork.UnitOfWork>((_, _) => Task.CompletedTask);
 

--- a/src/Fluss.Testing/AggregateTestBed.cs
+++ b/src/Fluss.Testing/AggregateTestBed.cs
@@ -17,7 +17,7 @@ public class AggregateTestBed<TAggregate, TKey> : EventTestBed where TAggregate 
     public AggregateTestBed()
     {
         var validator = new Mock<IRootValidator>();
-        validator.Setup(v => v.ValidateEvent(It.IsAny<EventEnvelope>()))
+        validator.Setup(v => v.ValidateEvent(It.IsAny<EventEnvelope>(), It.IsAny<IReadOnlyList<EventEnvelope>?>()))
             .Returns<EventEnvelope>(_ => Task.CompletedTask);
         validator.Setup(v => v.ValidateAggregate(It.IsAny<AggregateRoot>(), It.IsAny<UnitOfWork.UnitOfWork>()))
             .Returns<AggregateRoot, UnitOfWork.UnitOfWork>((_, _) => Task.CompletedTask);

--- a/src/Fluss.UnitTest/Core/UnitOfWork/UnitOfWorkTest.cs
+++ b/src/Fluss.UnitTest/Core/UnitOfWork/UnitOfWorkTest.cs
@@ -29,7 +29,7 @@ public partial class UnitOfWorkTest
 
         _validator = new Mock<IRootValidator>(MockBehavior.Strict);
         _validator.Setup(v => v.ValidateEvent(It.IsAny<EventEnvelope>(), It.IsAny<IReadOnlyList<EventEnvelope>?>()))
-            .Returns<EventEnvelope>(_ => Task.CompletedTask);
+            .Returns<EventEnvelope, IReadOnlyList<EventEnvelope>?>((_, _) => Task.CompletedTask);
         _validator.Setup(v => v.ValidateAggregate(It.IsAny<AggregateRoot>(), It.IsAny<Fluss.UnitOfWork.UnitOfWork>()))
             .Returns<AggregateRoot, Fluss.UnitOfWork.UnitOfWork>((_, _) => Task.CompletedTask);
 

--- a/src/Fluss.UnitTest/Core/UnitOfWork/UnitOfWorkTest.cs
+++ b/src/Fluss.UnitTest/Core/UnitOfWork/UnitOfWorkTest.cs
@@ -28,7 +28,7 @@ public partial class UnitOfWorkTest
         _policies = new List<Policy>();
 
         _validator = new Mock<IRootValidator>(MockBehavior.Strict);
-        _validator.Setup(v => v.ValidateEvent(It.IsAny<EventEnvelope>()))
+        _validator.Setup(v => v.ValidateEvent(It.IsAny<EventEnvelope>(), It.IsAny<IReadOnlyList<EventEnvelope>?>()))
             .Returns<EventEnvelope>(_ => Task.CompletedTask);
         _validator.Setup(v => v.ValidateAggregate(It.IsAny<AggregateRoot>(), It.IsAny<Fluss.UnitOfWork.UnitOfWork>()))
             .Returns<AggregateRoot, Fluss.UnitOfWork.UnitOfWork>((_, _) => Task.CompletedTask);

--- a/src/Fluss/UnitOfWork/UnitOfWork.Aggregates.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWork.Aggregates.cs
@@ -93,7 +93,11 @@ public partial class UnitOfWork
     {
         using var activity = FlussActivitySource.Source.StartActivity();
 
-        await Task.WhenAll(PublishedEventEnvelopes.Select(envelope => _validator.ValidateEvent(envelope)));
+        var validatedEnvelopes = new List<EventEnvelope>();
+        foreach (var envelope in PublishedEventEnvelopes) {
+            await _validator.ValidateEvent(envelope, validatedEnvelopes);
+            validatedEnvelopes.Add(envelope);
+        }
 
         await _eventRepository.Publish(PublishedEventEnvelopes);
         _consistentVersion += PublishedEventEnvelopes.Count;

--- a/src/Fluss/UnitOfWork/UnitOfWork.Aggregates.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWork.Aggregates.cs
@@ -94,7 +94,8 @@ public partial class UnitOfWork
         using var activity = FlussActivitySource.Source.StartActivity();
 
         var validatedEnvelopes = new List<EventEnvelope>();
-        foreach (var envelope in PublishedEventEnvelopes) {
+        foreach (var envelope in PublishedEventEnvelopes)
+        {
             await _validator.ValidateEvent(envelope, validatedEnvelopes);
             validatedEnvelopes.Add(envelope);
         }

--- a/src/Fluss/Validation/RootValidator.cs
+++ b/src/Fluss/Validation/RootValidator.cs
@@ -61,7 +61,8 @@ public class RootValidator : IRootValidator
         var willBePublishedEnvelopes = previousEnvelopes ?? new List<EventEnvelope>();
 
         var versionedUnitOfWork = unitOfWork.WithPrefilledVersion(envelope.Version - willBePublishedEnvelopes.Count - 1);
-        foreach (var willBePublishedEnvelope in willBePublishedEnvelopes) {
+        foreach (var willBePublishedEnvelope in willBePublishedEnvelopes)
+        {
             versionedUnitOfWork.PublishedEventEnvelopes.Enqueue(willBePublishedEnvelope);
         }
 


### PR DESCRIPTION
Fixes a bug with event-validation that occurs when committing multiple events at once where reading a readmodel inside the validation function threw an error because of an incorrect version / missing previous events.