### PR TITLE
Allow using IUnitOfWork as parameter

### DIFF
--- a/src/Fluss.HotChocolate/UnitOfWorkParameterExpressionBuilder.cs
+++ b/src/Fluss.HotChocolate/UnitOfWorkParameterExpressionBuilder.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
+using Fluss.UnitOfWork;
 using HotChocolate.Internal;
 using HotChocolate.Resolvers;
 
@@ -36,7 +37,8 @@ public class UnitOfWorkParameterExpressionBuilder : IParameterExpressionBuilder
         typeof(IHasContextData).GetProperty(
             nameof(IHasContextData.ContextData))!;
 
-    public bool CanHandle(ParameterInfo parameter) => typeof(UnitOfWork.UnitOfWork) == parameter.ParameterType;
+    public bool CanHandle(ParameterInfo parameter) => typeof(UnitOfWork.UnitOfWork) == parameter.ParameterType
+        || typeof(IUnitOfWork) == parameter.ParameterType;
 
     /*
      * Produces something like this: context.GetOrSetGlobalState(


### PR DESCRIPTION
Currently, it's not permitted to inject an `IUnitOfWork` into resolvers as a parameter. This makes it hard to re-use resolvers in other code or test them with mocks.

This PR extends the `UnitOfWorkParameterExpressionBuilder` to also apply to `IUnitOfWork` parameters instead of only `UnitOfWork.UnitOfWork`.