### PR TITLE
short-circuit for empty keys on GetMultipleReadModels

### DIFF
--- a/src/Fluss.UnitTest/Core/UnitOfWork/UnitOfWorkTest.cs
+++ b/src/Fluss.UnitTest/Core/UnitOfWork/UnitOfWorkTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Fluss.Aggregates;
 using Fluss.Authentication;
 using Fluss.Events;
@@ -251,6 +252,15 @@ public partial class UnitOfWorkTest
         Assert.Contains(unitOfWork.ReadModels, rm => rm == readModels[1]);
     }
 
+    [Fact]
+    public async Task ShortCircuitsReadingMultipleReadModelsOnEmptyKeys()
+    {
+        var unitOfWork = GetUnitOfWork();
+        var readModels = await unitOfWork.GetMultipleReadModels<TestReadModel, int>([]);
+
+        Assert.Empty(readModels);
+        Assert.Equal(ImmutableList<TestReadModel>.Empty, unitOfWork.ReadModels);
+    }
 
     [Fact]
     public async Task ReturnsNothingWhenMultipleReadModelNotAuthorized()
@@ -266,6 +276,16 @@ public partial class UnitOfWorkTest
         Assert.Equal(2, readModels[0].GotEvents);
         Assert.Equal(1, readModels[1].GotEvents);
         Assert.Equal(2, readModels.Count);
+    }
+
+    [Fact]
+    public async Task ShortCircuitsReadingMultipleReadModelsUnsafeOnEmptyKeys()
+    {
+        var unitOfWork = GetUnitOfWork();
+        var readModels = await unitOfWork.UnsafeGetMultipleReadModelsWithoutAuthorization<TestReadModel, int>([]);
+
+        Assert.Empty(readModels);
+        Assert.Equal(ImmutableList<TestReadModel>.Empty, unitOfWork.ReadModels);
     }
 
     [Fact]

--- a/src/Fluss/UnitOfWork/UnitOfWork.ReadModels.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWork.ReadModels.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Collections.Pooled;
 using Fluss.Events;
@@ -122,9 +123,10 @@ public partial class UnitOfWork
         using var activity = FlussActivitySource.Source.StartActivity();
         activity?.SetTag("EventSourcing.ReadModel", typeof(TReadModel).FullName);
 
-        var dictionary = new ConcurrentDictionary<TKey, TReadModel?>();
-
         var keysList = keys.ToList();
+        if (keysList.Count == 0) return ImmutableList<TReadModel>.Empty;
+
+        var dictionary = new ConcurrentDictionary<TKey, TReadModel?>();
 
         await Parallel.ForEachAsync(keysList, async (key, _) =>
         {
@@ -149,9 +151,10 @@ public partial class UnitOfWork
         UnsafeGetMultipleReadModelsWithoutAuthorization<TReadModel, TKey>(IEnumerable<TKey> keys, long? at = null)
         where TKey : notnull where TReadModel : EventListener, IReadModel, IEventListenerWithKey<TKey>, new()
     {
-        var dictionary = new ConcurrentDictionary<TKey, TReadModel>();
-
         var keysList = keys.ToList();
+        if (keysList.Count == 0) return ImmutableList<TReadModel>.Empty;
+
+        var dictionary = new ConcurrentDictionary<TKey, TReadModel>();
 
         await Parallel.ForEachAsync(keysList, async (key, _) =>
         {


### PR DESCRIPTION
This PR adds short-circuiting to `UnitOfWork.GetMultipleReadModels` and `UnitOfWork.UnsafeGetMultipleReadModelsWithoutAuthorization` to avoid the overhead of `Parallel.ForEachAsync` in cases where no key is passed anyway.

I am not really happy with the test, tbh because it does not *really* test the short-circuit but I couldn't find a good way of ensuring `Parallel.ForEachAsync` isn't actually called. If this can be improved, let me know!