### PR TITLE
fix: expose GetAggregateRoot()

### DIFF
--- a/src/Fluss/UnitOfWork/IWriteUnitOfWork.cs
+++ b/src/Fluss/UnitOfWork/IWriteUnitOfWork.cs
@@ -7,6 +7,9 @@ public interface IWriteUnitOfWork : IUnitOfWork
 {
     ValueTask<TAggregate> GetAggregate<TAggregate, TKey>(TKey key)
         where TAggregate : AggregateRoot<TKey>, new();
+    
+    ValueTask<TAggregate> GetAggregate<TAggregate>()
+        where TAggregate : AggregateRoot, new();
 
     ValueTask Publish(Event @event, AggregateRoot? aggregate = null);
 }

--- a/src/Fluss/UnitOfWork/IWriteUnitOfWork.cs
+++ b/src/Fluss/UnitOfWork/IWriteUnitOfWork.cs
@@ -7,7 +7,7 @@ public interface IWriteUnitOfWork : IUnitOfWork
 {
     ValueTask<TAggregate> GetAggregate<TAggregate, TKey>(TKey key)
         where TAggregate : AggregateRoot<TKey>, new();
-    
+
     ValueTask<TAggregate> GetAggregate<TAggregate>()
         where TAggregate : AggregateRoot, new();
 


### PR DESCRIPTION
This PR exposes supposedly public API on the `IWriteUnitOfWork` interface.