### PR TITLE
feat: generate separate registrations

### DIFF
--- a/src/Fluss.Regen/Generators/RegistrationSyntaxGenerator.cs
+++ b/src/Fluss.Regen/Generators/RegistrationSyntaxGenerator.cs
@@ -41,7 +41,7 @@ public sealed class RegistrationSyntaxGenerator : IDisposable
 
     public void WriteBeginClass()
     {
-        _writer.WriteIndentedLine("public static partial class {0}ServiceCollectionExtensions {{", _moduleName);
+        _writer.WriteIndentedLine("public static partial class {0}ComponentsServiceCollectionExtensions {{", _moduleName);
         _writer.IncreaseIndent();
     }
 
@@ -99,7 +99,7 @@ public sealed class RegistrationSyntaxGenerator : IDisposable
     {
         _writer.WriteIndentedLine("Add{0}{1}(sc);", _moduleName, componentName);
     }
-    
+
     public override string ToString()
         => _sb.ToString();
 

--- a/src/Fluss.Regen/Generators/RegistrationSyntaxGenerator.cs
+++ b/src/Fluss.Regen/Generators/RegistrationSyntaxGenerator.cs
@@ -51,19 +51,23 @@ public sealed class RegistrationSyntaxGenerator : IDisposable
         _writer.WriteIndentedLine("}");
     }
 
-    public void WriteBeginRegistrationMethod()
+    public void WriteBeginRegistrationMethod(string componentType)
     {
         _writer.WriteIndentedLine(
-            "public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection Add{0}(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {{",
-            _moduleName);
+            "public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection Add{0}{1}(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {{",
+            _moduleName, componentType);
         _writer.IncreaseIndent();
     }
 
-    public void WriteEndRegistrationMethod()
+    public void WriteEndRegistrationMethod(bool includeNewLine = true)
     {
         _writer.WriteIndentedLine("return sc;");
         _writer.DecreaseIndent();
         _writer.WriteIndentedLine("}");
+        if (includeNewLine)
+        {
+            _writer.WriteLine();
+        }
     }
 
     public void WriteAggregateValidatorRegistration(string aggregateValidatorType)
@@ -91,6 +95,11 @@ public sealed class RegistrationSyntaxGenerator : IDisposable
         _writer.WriteIndentedLine("global::Fluss.ServiceCollectionExtensions.AddUpcaster<{0}>(sc);", upcasterType);
     }
 
+    public void WriteComponentRegistration(string componentName)
+    {
+        _writer.WriteIndentedLine("Add{0}{1}(sc);", _moduleName, componentName);
+    }
+    
     public override string ToString()
         => _sb.ToString();
 

--- a/src/Fluss.Regen/SelectorGenerator.cs
+++ b/src/Fluss.Regen/SelectorGenerator.cs
@@ -197,7 +197,7 @@ public class SelectorGenerator : IIncrementalGenerator
         generator.WriteHeader();
         generator.WriteBeginNamespace();
         generator.WriteBeginClass();
-        
+
         var foundInfo = false;
 
         var aggregateValidators = syntaxInfos.OfType<AggregateValidatorInfo>().ToImmutableHashSet();
@@ -205,7 +205,7 @@ public class SelectorGenerator : IIncrementalGenerator
         if (aggregateValidators.Any() || eventValidators.Any())
         {
             generator.WriteBeginRegistrationMethod("Validators");
-            
+
             foreach (var aggregateValidator in aggregateValidators)
             {
                 generator.WriteAggregateValidatorRegistration(aggregateValidator.Type.ToFullyQualified());
@@ -214,11 +214,11 @@ public class SelectorGenerator : IIncrementalGenerator
             {
                 generator.WriteEventValidatorRegistration(eventValidator.Type.ToFullyQualified());
             }
-            
+
             generator.WriteEndRegistrationMethod();
             foundInfo = true;
         }
-        
+
         var policies = syntaxInfos.OfType<PolicyInfo>().ToImmutableHashSet();
         if (policies.Any())
         {
@@ -230,7 +230,7 @@ public class SelectorGenerator : IIncrementalGenerator
             generator.WriteEndRegistrationMethod();
             foundInfo = true;
         }
-        
+
         var sideEffects = syntaxInfos.OfType<SideEffectInfo>().ToImmutableHashSet();
         if (sideEffects.Any())
         {
@@ -242,7 +242,7 @@ public class SelectorGenerator : IIncrementalGenerator
             generator.WriteEndRegistrationMethod();
             foundInfo = true;
         }
-        
+
         var upcasters = syntaxInfos.OfType<UpcasterInfo>().ToImmutableHashSet();
         if (upcasters.Any())
         {
@@ -254,7 +254,7 @@ public class SelectorGenerator : IIncrementalGenerator
             generator.WriteEndRegistrationMethod();
             foundInfo = true;
         }
-        
+
         generator.WriteBeginRegistrationMethod("Components");
         if (aggregateValidators.Any() || eventValidators.Any())
         {

--- a/src/Fluss.Regen/SelectorGenerator.cs
+++ b/src/Fluss.Regen/SelectorGenerator.cs
@@ -190,45 +190,93 @@ public class SelectorGenerator : IIncrementalGenerator
             return;
         }
 
-        var moduleName = (compilation.AssemblyName ?? "Assembly").Split('.').Last() + "ESComponents";
+        var moduleName = (compilation.AssemblyName ?? "Assembly").Split('.').Last() + "ES";
 
         using var generator = new RegistrationSyntaxGenerator(moduleName, "Microsoft.Extensions.DependencyInjection");
 
         generator.WriteHeader();
         generator.WriteBeginNamespace();
         generator.WriteBeginClass();
-        generator.WriteBeginRegistrationMethod();
-
+        
         var foundInfo = false;
 
-        foreach (var syntaxInfo in syntaxInfos)
+        var aggregateValidators = syntaxInfos.OfType<AggregateValidatorInfo>().ToImmutableHashSet();
+        var eventValidators = syntaxInfos.OfType<EventValidatorInfo>().ToImmutableHashSet();
+        if (aggregateValidators.Any() || eventValidators.Any())
         {
-            switch (syntaxInfo)
+            generator.WriteBeginRegistrationMethod("Validators");
+            
+            foreach (var aggregateValidator in aggregateValidators)
             {
-                case AggregateValidatorInfo aggregateValidatorInfo:
-                    generator.WriteAggregateValidatorRegistration(aggregateValidatorInfo.Type.ToFullyQualified());
-                    foundInfo = true;
-                    break;
-                case EventValidatorInfo eventValidatorInfo:
-                    generator.WriteEventValidatorRegistration(eventValidatorInfo.Type.ToFullyQualified());
-                    foundInfo = true;
-                    break;
-                case PolicyInfo policyInfo:
-                    generator.WritePolicyRegistration(policyInfo.Type.ToFullyQualified());
-                    foundInfo = true;
-                    break;
-                case SideEffectInfo sideEffectInfo:
-                    generator.WriteSideEffectRegistration(sideEffectInfo.Type.ToFullyQualified());
-                    foundInfo = true;
-                    break;
-                case UpcasterInfo upcasterInfo:
-                    generator.WriteUpcasterRegistration(upcasterInfo.Type.ToFullyQualified());
-                    foundInfo = true;
-                    break;
+                generator.WriteAggregateValidatorRegistration(aggregateValidator.Type.ToFullyQualified());
             }
+            foreach (var eventValidator in eventValidators)
+            {
+                generator.WriteEventValidatorRegistration(eventValidator.Type.ToFullyQualified());
+            }
+            
+            generator.WriteEndRegistrationMethod();
+            foundInfo = true;
+        }
+        
+        var policies = syntaxInfos.OfType<PolicyInfo>().ToImmutableHashSet();
+        if (policies.Any())
+        {
+            generator.WriteBeginRegistrationMethod("Policies");
+            foreach (var policy in policies)
+            {
+                generator.WritePolicyRegistration(policy.Type.ToFullyQualified());
+            }
+            generator.WriteEndRegistrationMethod();
+            foundInfo = true;
+        }
+        
+        var sideEffects = syntaxInfos.OfType<SideEffectInfo>().ToImmutableHashSet();
+        if (sideEffects.Any())
+        {
+            generator.WriteBeginRegistrationMethod("SideEffects");
+            foreach (var sideEffect in sideEffects)
+            {
+                generator.WriteSideEffectRegistration(sideEffect.Type.ToFullyQualified());
+            }
+            generator.WriteEndRegistrationMethod();
+            foundInfo = true;
+        }
+        
+        var upcasters = syntaxInfos.OfType<UpcasterInfo>().ToImmutableHashSet();
+        if (upcasters.Any())
+        {
+            generator.WriteBeginRegistrationMethod("Upcasters");
+            foreach (var upcaster in upcasters)
+            {
+                generator.WriteUpcasterRegistration(upcaster.Type.ToFullyQualified());
+            }
+            generator.WriteEndRegistrationMethod();
+            foundInfo = true;
+        }
+        
+        generator.WriteBeginRegistrationMethod("Components");
+        if (aggregateValidators.Any() || eventValidators.Any())
+        {
+            generator.WriteComponentRegistration("Validators");
         }
 
-        generator.WriteEndRegistrationMethod();
+        if (policies.Any())
+        {
+            generator.WriteComponentRegistration("Policies");
+        }
+
+        if (sideEffects.Any())
+        {
+            generator.WriteComponentRegistration("SideEffects");
+        }
+
+        if (upcasters.Any())
+        {
+            generator.WriteComponentRegistration("Upcasters");
+        }
+
+        generator.WriteEndRegistrationMethod(false);
         generator.WriteEndClass();
         generator.WriteEndNamespace();
 

--- a/src/Fluss.UnitTest/Regen/SelectorGeneratorTests.cs
+++ b/src/Fluss.UnitTest/Regen/SelectorGeneratorTests.cs
@@ -1,4 +1,3 @@
-using Fluss.Events;
 using Fluss.Regen;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForEventValidator.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForEventValidator.DotNet8_0#Registration.g.verified.cs
@@ -7,7 +7,7 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
         public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESValidators(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Validation.ValidationServiceCollectionExtension.AddEventValidator<global::TestNamespace.TestEventValidator>(sc);
             return sc;

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForEventValidator.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForEventValidator.DotNet8_0#Registration.g.verified.cs
@@ -7,9 +7,14 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESValidators(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Validation.ValidationServiceCollectionExtension.AddEventValidator<global::TestNamespace.TestEventValidator>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESValidators(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForEventValidator.DotNet9_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForEventValidator.DotNet9_0#Registration.g.verified.cs
@@ -8,8 +8,13 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
     public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESValidators(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Validation.ValidationServiceCollectionExtension.AddEventValidator<global::TestNamespace.TestEventValidator>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESValidators(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForPolicy.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForPolicy.DotNet8_0#Registration.g.verified.cs
@@ -7,7 +7,7 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
         public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESPolicies(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Authentication.ServiceCollectionExtensions.AddPolicy<global::TestNamespace.TestPolicy>(sc);
             return sc;

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForPolicy.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForPolicy.DotNet8_0#Registration.g.verified.cs
@@ -7,9 +7,14 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESPolicies(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Authentication.ServiceCollectionExtensions.AddPolicy<global::TestNamespace.TestPolicy>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESPolicies(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForPolicy.DotNet9_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForPolicy.DotNet9_0#Registration.g.verified.cs
@@ -8,8 +8,13 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
     public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESPolicies(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Authentication.ServiceCollectionExtensions.AddPolicy<global::TestNamespace.TestPolicy>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESPolicies(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForSideEffect.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForSideEffect.DotNet8_0#Registration.g.verified.cs
@@ -7,9 +7,14 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESSideEffects(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.SideEffects.SideEffectsServiceCollectionExtension.AddSideEffect<global::TestNamespace.TestSideEffect>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESSideEffects(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForSideEffect.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForSideEffect.DotNet8_0#Registration.g.verified.cs
@@ -7,7 +7,7 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
         public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESSideEffects(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.SideEffects.SideEffectsServiceCollectionExtension.AddSideEffect<global::TestNamespace.TestSideEffect>(sc);
             return sc;

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForSideEffect.DotNet9_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForSideEffect.DotNet9_0#Registration.g.verified.cs
@@ -8,8 +8,13 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
     public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESSideEffects(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.SideEffects.SideEffectsServiceCollectionExtension.AddSideEffect<global::TestNamespace.TestSideEffect>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESSideEffects(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForUpcaster.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForUpcaster.DotNet8_0#Registration.g.verified.cs
@@ -7,9 +7,14 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESUpcasters(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.ServiceCollectionExtensions.AddUpcaster<global::TestNamespace.TestUpcaster>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESUpcasters(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForUpcaster.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForUpcaster.DotNet8_0#Registration.g.verified.cs
@@ -7,7 +7,7 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
         public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESUpcasters(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.ServiceCollectionExtensions.AddUpcaster<global::TestNamespace.TestUpcaster>(sc);
             return sc;

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForUpcaster.DotNet9_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GenerateForUpcaster.DotNet9_0#Registration.g.verified.cs
@@ -8,8 +8,13 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
     public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESUpcasters(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.ServiceCollectionExtensions.AddUpcaster<global::TestNamespace.TestUpcaster>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESUpcasters(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GeneratesForAggregateValidator.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GeneratesForAggregateValidator.DotNet8_0#Registration.g.verified.cs
@@ -7,7 +7,7 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
         public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESValidators(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Validation.ValidationServiceCollectionExtension.AddAggregateValidator<global::TestNamespace.TestAggregateValidator>(sc);
             return sc;

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GeneratesForAggregateValidator.DotNet8_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GeneratesForAggregateValidator.DotNet8_0#Registration.g.verified.cs
@@ -7,9 +7,14 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
-    public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+    public static partial class SelectorGeneratorTestsESServiceCollectionExtensions {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESValidators(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Validation.ValidationServiceCollectionExtension.AddAggregateValidator<global::TestNamespace.TestAggregateValidator>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESValidators(sc);
             return sc;
         }
     }

--- a/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GeneratesForAggregateValidator.DotNet9_0#Registration.g.verified.cs
+++ b/src/Fluss.UnitTest/Regen/Snapshots/SelectorGeneratorTests.GeneratesForAggregateValidator.DotNet9_0#Registration.g.verified.cs
@@ -8,8 +8,13 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection {
     public static partial class SelectorGeneratorTestsESComponentsServiceCollectionExtensions {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESValidators(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
             global::Fluss.Validation.ValidationServiceCollectionExtension.AddAggregateValidator<global::TestNamespace.TestAggregateValidator>(sc);
+            return sc;
+        }
+
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddSelectorGeneratorTestsESComponents(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection sc) {
+            AddSelectorGeneratorTestsESValidators(sc);
             return sc;
         }
     }


### PR DESCRIPTION
This PR adds support for adding individual ES components (like Validators or Policies) to a servicecollection instead of getting either all or nothing.

