### PR TITLE
feat: publish debug symbols

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+    <PropertyGroup>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR configures the projects to include debug symbols in the new snupkg-format to be pushed to NuGet for a better debugging experience.

