### PR TITLE
fix: startup deadlock

### DIFF
--- a/src/Fluss.PostgreSQL/ServiceCollectionExtensions.cs
+++ b/src/Fluss.PostgreSQL/ServiceCollectionExtensions.cs
@@ -65,13 +65,16 @@ public class Migrator(ILogger<Migrator> logger, IServiceProvider serviceProvider
                 var migrationRunner = scope.ServiceProvider.GetRequiredService<IMigrationRunner>();
                 migrationRunner.MigrateUp();
 
-                _didFinish = true;
-                _didFinishChanged.Release();
             }
             catch (Exception e)
             {
                 logger.LogError(e, "Error while migrating");
                 Environment.Exit(-1);
+            }
+            finally
+            {
+                _didFinish = true;
+                _didFinishChanged.Release();
             }
         }, stoppingToken);
     }

--- a/src/Fluss/SideEffects/SideEffectDispatcher.cs
+++ b/src/Fluss/SideEffects/SideEffectDispatcher.cs
@@ -32,11 +32,16 @@ public sealed class SideEffectDispatcher : IHostedService
         CacheSideEffects(sideEffects);
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        Init();
+        return Task.CompletedTask;
+    }
+
+    private async void Init()
     {
         var upcaster = _serviceProvider.GetRequiredService<EventUpcasterService>();
         await upcaster.WaitForCompletionAsync();
-
         _transientEventRepository.NewEvents += HandleNewEvents;
         _transientEventRepository.NewTransientEvents += HandleNewTransientEvents;
     }

--- a/src/Fluss/Upcasting/EventUpcasterService.cs
+++ b/src/Fluss/Upcasting/EventUpcasterService.cs
@@ -17,7 +17,7 @@ public class EventUpcasterService(
 {
     private readonly List<IUpcaster> _sortedUpcasters = sorter.SortByDependencies(upcasters);
 
-    private readonly CancellationTokenSource _onCompletedSource = new();
+    private readonly TaskCompletionSource _onCompletedSource = new();
 
     public async ValueTask Run()
     {
@@ -47,13 +47,11 @@ public class EventUpcasterService(
             events = upcastedEvents;
         }
 
-        _onCompletedSource.Cancel();
+        _onCompletedSource.SetResult();
     }
 
     public async Task WaitForCompletionAsync()
     {
-        var tcs = new TaskCompletionSource<bool>();
-        _onCompletedSource.Token.Register(s => ((TaskCompletionSource<bool>)s!).SetResult(true), tcs);
-        await tcs.Task;
+        await _onCompletedSource.Task;
     }
 }


### PR DESCRIPTION
This PR fixes a deadlock in startup that occurs when placing .AddEventSourcing() before .AddPostgresEventSourcingRepository(). This caused the the SideEffectDispatcher to wait for Upcasting to be finished while the Upcaster as HostedService waits for the SideEffectDispatcher StartAsync to finish.

