### PR TITLE
fix: unit of work policies

### DIFF
--- a/src/Fluss.PostgreSQL.IntegrationTest/PostgreSQLTest.cs
+++ b/src/Fluss.PostgreSQL.IntegrationTest/PostgreSQLTest.cs
@@ -398,6 +398,9 @@ public class PostgreSQLTest : IAsyncLifetime
             }
         };
 
+        // Short delay to allow database trigger to register
+        await Task.Delay(1000);
+
         // Publish an event using the first repository
         await repository1.Publish([
             new EventEnvelope
@@ -410,13 +413,13 @@ public class PostgreSQLTest : IAsyncLifetime
         ]);
 
         // Wait for both event handlers to be triggered or timeout after 5 seconds
-        var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
-        var allTasks = await Task.WhenAny(
+        var timeoutTask = Task.Delay(TimeSpan.FromSeconds(10));
+        var fasterTask = await Task.WhenAny(
             Task.WhenAll(eventRaised1.Task, eventRaised2.Task),
             timeoutTask
         );
 
-        Assert.NotEqual(timeoutTask, allTasks);
+        Assert.True(timeoutTask != fasterTask, "Ran into timeout");
         Assert.True(await eventRaised1.Task, "NewEvents event was not raised on the first repository");
         Assert.True(await eventRaised2.Task, "NewEvents event was not raised on the second repository");
     }

--- a/src/Fluss/UnitOfWork/UnitOfWork.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWork.cs
@@ -34,7 +34,6 @@ public partial class UnitOfWork : IWriteUnitOfWork
         var unitOfWork = Pool.Get();
         unitOfWork._eventRepository = eventRepository;
         unitOfWork._eventListenerFactory = eventListenerFactory;
-        unitOfWork._policies.Clear();
         unitOfWork._policies.AddRange(policies);
         unitOfWork._userIdProvider = userIdProvider;
         unitOfWork._validator = validator;

--- a/src/Fluss/UnitOfWork/UnitOfWork.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWork.cs
@@ -34,6 +34,7 @@ public partial class UnitOfWork : IWriteUnitOfWork
         var unitOfWork = Pool.Get();
         unitOfWork._eventRepository = eventRepository;
         unitOfWork._eventListenerFactory = eventListenerFactory;
+        unitOfWork._policies.Clear();
         unitOfWork._policies.AddRange(policies);
         unitOfWork._userIdProvider = userIdProvider;
         unitOfWork._validator = validator;


### PR DESCRIPTION
This PR ensures that an existing UnitOfWork taken from the Pool does not stack policies each time it is re-used.