### PR TITLE
fix: IUnitOfWork injection

### DIFF
--- a/src/Fluss.HotChocolate/AddExtensionMiddleware.cs
+++ b/src/Fluss.HotChocolate/AddExtensionMiddleware.cs
@@ -21,7 +21,7 @@ public class AddExtensionMiddleware(
     {
         await _next.Invoke(context);
 
-        if (!context.ContextData.TryGetValue(nameof(UnitOfWork), out var unitOfWork))
+        if (!context.ContextData.TryGetValue(nameof(IUnitOfWork), out var unitOfWork))
         {
             return;
         }
@@ -38,7 +38,7 @@ public class AddExtensionMiddleware(
         {
             if (context.Result is QueryResult subsequentQueryResult)
             {
-                context.Result = QueryResultBuilder.FromResult(subsequentQueryResult).AddContextData(nameof(UnitOfWork),
+                context.Result = QueryResultBuilder.FromResult(subsequentQueryResult).AddContextData(nameof(IUnitOfWork),
 unitOfWork).Create();
             }
 
@@ -84,7 +84,7 @@ unitOfWork).Create();
 
         while (true)
         {
-            if (contextData == null || !contextData.TryGetValue(nameof(UnitOfWork), out var value))
+            if (contextData == null || !contextData.TryGetValue(nameof(IUnitOfWork), out var value))
             {
                 break;
             }

--- a/src/Fluss.UnitTest/HotChocolate/UnitOfWorkParameterExpressionBuilderTest.cs
+++ b/src/Fluss.UnitTest/HotChocolate/UnitOfWorkParameterExpressionBuilderTest.cs
@@ -12,10 +12,10 @@ public class UnitOfWorkParameterExpressionBuilderTest
     private readonly UnitOfWorkParameterExpressionBuilder _builder = new();
 
     [Fact]
-    public void CanHandle_ShouldReturnTrueForUnitOfWorkParameter()
+    public void CanHandle_ShouldReturnFalseForUnitOfWorkParameter()
     {
         var parameter = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithUnitOfWork))!.GetParameters()[0];
-        Assert.True(_builder.CanHandle(parameter));
+        Assert.False(_builder.CanHandle(parameter));
     }
 
     [Fact]
@@ -39,9 +39,9 @@ public class UnitOfWorkParameterExpressionBuilderTest
     }
 
     [Fact]
-    public void IsPure_ShouldReturnTrue()
+    public void IsPure_ShouldReturnFalse()
     {
-        Assert.True(_builder.IsPure);
+        Assert.False(_builder.IsPure);
     }
 
     [Fact]


### PR DESCRIPTION
This PR fixes injection of the IUnitOfWork parameter for HotChocolate resolvers.

- Limit parameter resolution to IUnitOfWork because `.WithPrefilledVersion` returns an `IUnitOfWork`
- Mark the expression builder as not pure for two reasons:
    - It isn't: Building a unit of work writes to a global state
    - Marking the builder as pure causes HC to sometimes inject an `IPureResolverContext`, breaking the expression which requires an `IResolverContext` and not a pure one