### PR TITLE
fix: arbitraryUserUnitOfWork creation

### DIFF
--- a/src/Fluss/Authentication/ArbitraryUserUnitOfWorkExtension.cs
+++ b/src/Fluss/Authentication/ArbitraryUserUnitOfWorkExtension.cs
@@ -42,16 +42,22 @@ public class ArbitraryUserUnitOfWorkCache(IServiceProvider serviceProvider) : IA
         collection.AddSingleton<IRootValidator>(_ => serviceProvider.GetRequiredService<IRootValidator>());
 
         collection.ProvideUserIdFrom(_ => providedId);
-        collection.AddTransient<UnitOfWork>(sp => UnitOfWork.Create(
+        collection.AddTransient<UnitOfWork>(CreateUnitOfWork);
+        collection.AddTransient<IUnitOfWork>(CreateUnitOfWork);
+        collection.AddTransient<UnitOfWorkFactory>();
+
+        return collection.BuildServiceProvider();
+    }
+
+    private UnitOfWork CreateUnitOfWork(IServiceProvider sp)
+    {
+        return UnitOfWork.Create(
             sp.GetRequiredService<IEventRepository>(),
             sp.GetRequiredService<IEventListenerFactory>(),
             sp.GetServices<Policy>(),
             sp.GetRequiredService<UserIdProvider>(),
-            sp.GetRequiredService<IRootValidator>()));
-        collection.AddTransient<IUnitOfWork>(sp => sp.GetRequiredService<UnitOfWork>());
-        collection.AddTransient<UnitOfWorkFactory>();
-
-        return collection.BuildServiceProvider();
+            sp.GetRequiredService<IRootValidator>()
+        );
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue with UnitOfWork being disposed of twice due to misconfiguration of the CI. This issue was fixed for the "normal" UnitOfWork in https://github.com/atmina/fluss/pull/51/files#diff-605bdf2f6abead26368eb146c500abb4d67b258f27610c674fef2c99893ae993L42-L48 but overlooked in the extension for arbitrary users.

