### PR TITLE
Improved Selector Caching

### DIFF
--- a/src/Fluss.HotChocolate/Fluss.HotChocolate.csproj
+++ b/src/Fluss.HotChocolate/Fluss.HotChocolate.csproj
@@ -11,7 +11,6 @@
         <RepositoryUrl>https://github.com/atmina/fluss</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Fluss.UnitTest/.gitignore
+++ b/src/Fluss.UnitTest/.gitignore
@@ -1,0 +1,2 @@
+TestResults/
+

--- a/src/Fluss/UnitOfWork/IUnitOfWork.cs
+++ b/src/Fluss/UnitOfWork/IUnitOfWork.cs
@@ -34,4 +34,5 @@ public interface IUnitOfWork : IDisposable
         where TKey : notnull where TReadModel : EventListener, IReadModel, IEventListenerWithKey<TKey>, new();
 
     IUnitOfWork WithPrefilledVersion(long? version);
+    IUnitOfWork CopyWithVersion(long version);
 }

--- a/src/Fluss/UnitOfWork/UnitOfWork.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWork.cs
@@ -90,6 +90,14 @@ public partial class UnitOfWork : IWriteUnitOfWork
         return this;
     }
 
+    public IUnitOfWork CopyWithVersion(long version)
+    {
+        EnsureInstantiated();
+
+        var unitOfWork = Create(_eventRepository!, _eventListenerFactory!, _policies, _userIdProvider!, _validator!);
+        return unitOfWork.WithPrefilledVersion(version);
+    }
+
     private Guid CurrentUserId()
     {
         EnsureInstantiated();

--- a/src/Fluss/UnitOfWork/UnitOfWorkRecordingProxy.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWorkRecordingProxy.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Fluss.Events;
 using Fluss.ReadModel;
 
 namespace Fluss;
+
+public class AtNotAllowedInSelectorException : Exception;
 
 public class UnitOfWorkRecordingProxy(IUnitOfWork impl) : IUnitOfWork
 {
@@ -18,42 +19,54 @@ public class UnitOfWorkRecordingProxy(IUnitOfWork impl) : IUnitOfWork
 
     public ValueTask<IReadModel> GetReadModel([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type tReadModel, object? key, long? at = null)
     {
+        if (at.HasValue) throw new AtNotAllowedInSelectorException();
         return impl.GetReadModel(tReadModel, key, at);
     }
 
     public ValueTask<TReadModel> GetReadModel<TReadModel>(long? at = null) where TReadModel : EventListener, IRootEventListener, IReadModel, new()
     {
+        if (at.HasValue) throw new AtNotAllowedInSelectorException();
         return Record(impl.GetReadModel<TReadModel>(at));
     }
 
     public ValueTask<TReadModel> GetReadModel<TReadModel, TKey>(TKey key, long? at = null) where TReadModel : EventListener, IEventListenerWithKey<TKey>, IReadModel, new()
     {
+        if (at.HasValue) throw new AtNotAllowedInSelectorException();
         return Record(impl.GetReadModel<TReadModel, TKey>(key, at));
     }
 
     public ValueTask<TReadModel> UnsafeGetReadModelWithoutAuthorization<TReadModel>(long? at = null) where TReadModel : EventListener, IRootEventListener, IReadModel, new()
     {
+        if (at.HasValue) throw new AtNotAllowedInSelectorException();
         return Record(impl.UnsafeGetReadModelWithoutAuthorization<TReadModel>(at));
     }
 
     public ValueTask<TReadModel> UnsafeGetReadModelWithoutAuthorization<TReadModel, TKey>(TKey key, long? at = null) where TReadModel : EventListener, IEventListenerWithKey<TKey>, IReadModel, new()
     {
+        if (at.HasValue) throw new AtNotAllowedInSelectorException();
         return Record(impl.UnsafeGetReadModelWithoutAuthorization<TReadModel, TKey>(key, at));
     }
 
     public ValueTask<IReadOnlyList<TReadModel>> GetMultipleReadModels<TReadModel, TKey>(IEnumerable<TKey> keys, long? at = null) where TReadModel : EventListener, IReadModel, IEventListenerWithKey<TKey>, new() where TKey : notnull
     {
+        if (at.HasValue) throw new AtNotAllowedInSelectorException();
         return Record(impl.GetMultipleReadModels<TReadModel, TKey>(keys, at));
     }
 
     public ValueTask<IReadOnlyList<TReadModel>> UnsafeGetMultipleReadModelsWithoutAuthorization<TReadModel, TKey>(IEnumerable<TKey> keys, long? at = null) where TReadModel : EventListener, IReadModel, IEventListenerWithKey<TKey>, new() where TKey : notnull
     {
+        if (at.HasValue) throw new AtNotAllowedInSelectorException();
         return Record(impl.UnsafeGetMultipleReadModelsWithoutAuthorization<TReadModel, TKey>(keys, at));
     }
 
     public IUnitOfWork WithPrefilledVersion(long? version)
     {
-        return impl.WithPrefilledVersion(version);
+        throw new AtNotAllowedInSelectorException();
+    }
+
+    public IUnitOfWork CopyWithVersion(long version)
+    {
+        throw new AtNotAllowedInSelectorException();
     }
 
     private async ValueTask<TReadModel> Record<TReadModel>(ValueTask<TReadModel> readModel) where TReadModel : EventListener


### PR DESCRIPTION
This PR aims to improve selector handling for selectors using a fixed version for their events. Currently this slows down everything by a factor of 4-5x.

- **chore: Ignore test artifacts**
- **feat: more refined selector handling**
