### PR TITLE
fix: writing failed events

### DIFF
--- a/src/Fluss.HotChocolate.IntegrationTest/HotChocolateTest.cs
+++ b/src/Fluss.HotChocolate.IntegrationTest/HotChocolateTest.cs
@@ -104,7 +104,7 @@ public class Tests
         socket.Options.AddSubProtocol("graphql-transport-ws");
         await socket.ConnectAsync(new Uri(Address.Replace("http", "ws") + "/graphql"), CancellationToken.None);
 
-        Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
             while (true)
             {

--- a/src/Fluss.UnitTest/Core/UnitOfWork/UnitOfWorkTest.cs
+++ b/src/Fluss.UnitTest/Core/UnitOfWork/UnitOfWorkTest.cs
@@ -336,7 +336,7 @@ public partial class UnitOfWorkTest
     public async Task FailingCommitDoesNotCacheEventsToWrite()
     {
         _policies.Add(new AllowAllPolicy());
-        
+
         try
         {
             await _unitOfWorkFactory.Commit(async unitOfWork =>
@@ -352,10 +352,10 @@ public partial class UnitOfWorkTest
         }
 
         await _unitOfWorkFactory.Commit(_ => ValueTask.CompletedTask);
-        
+
         var unitOfWork = GetUnitOfWork();
         var aggregate = await unitOfWork.GetAggregate<TestAggregate, int>(100);
-        
+
         Assert.False(aggregate.Exists);
     }
 

--- a/src/Fluss/UnitOfWork/UnitOfWork.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWork.cs
@@ -105,7 +105,6 @@ public partial class UnitOfWork : IWriteUnitOfWork
         _validator = null;
         _userIdProvider = null;
         _consistentVersion = null;
-        
         PublishedEventEnvelopes.Clear();
         _readModels.Clear();
         _isInstantiated = false;

--- a/src/Fluss/UnitOfWork/UnitOfWork.cs
+++ b/src/Fluss/UnitOfWork/UnitOfWork.cs
@@ -105,6 +105,8 @@ public partial class UnitOfWork : IWriteUnitOfWork
         _validator = null;
         _userIdProvider = null;
         _consistentVersion = null;
+        
+        PublishedEventEnvelopes.Clear();
         _readModels.Clear();
         _isInstantiated = false;
 


### PR DESCRIPTION
This PR fixes a bug that caused failed events to still be written to the EventRepository. The bug occurs when a commit fails and the UnitOfWork that was used in the failing commit is later re-used. This happens because the PublishedEventEnvelopes are not cleared on Return to the pool but only on a successful commit.

