### PR TITLE
feat: initial metrics

### DIFF
--- a/src/Fluss/Metrics/FlussMetrics.cs
+++ b/src/Fluss/Metrics/FlussMetrics.cs
@@ -1,0 +1,8 @@
+﻿using System.Diagnostics.Metrics;
+
+namespace Fluss.Metrics;
+
+public class FlussMetrics
+{
+    public static readonly Meter Meter = new("fluss");
+}


### PR DESCRIPTION
This PR adds some initial metrics to Fluss, namely

- Active number of UnitOfWork instances
- Number of concurrent queries held in the Fluss.HotChocolate live-query middleware

This is a partial effort to resolve #71

