### PR TITLE
fix: livequeries not terminating

### DIFF
--- a/src/Fluss.HotChocolate.IntegrationTest/Fluss.HotChocolate.IntegrationTest.csproj
+++ b/src/Fluss.HotChocolate.IntegrationTest/Fluss.HotChocolate.IntegrationTest.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.9.1" />
         <PackageReference Include="NUnit" Version="4.1.0"/>
         <PackageReference Include="NUnit.Analyzers" Version="4.2.0"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>

--- a/src/Fluss.HotChocolate/AddExtensionMiddleware.cs
+++ b/src/Fluss.HotChocolate/AddExtensionMiddleware.cs
@@ -16,7 +16,7 @@ public class AddExtensionMiddleware(
     ILogger<AddExtensionMiddleware> logger)
 {
     private const string SubsequentRequestMarker = nameof(AddExtensionMiddleware) + ".subsequentRequestMarker";
-    private static readonly UpDownCounter<int> ActiveLiveQueries = FlussMetrics.Meter.CreateUpDownCounter<int>(
+    internal static readonly UpDownCounter<int> ActiveLiveQueries = FlussMetrics.Meter.CreateUpDownCounter<int>(
         "active_live_queries",
         unit: "Queries",
         description: "Number of active Live Queries stuck in a while loop."
@@ -138,7 +138,8 @@ unitOfWork).Create();
 
             await using var executionResult = await serviceProvider.ExecuteRequestAsync(readOnlyQueryRequest);
 
-            if (executionResult is not IQueryResult result)
+            if (executionResult is not IQueryResult result
+                || contextSocketSession is ISocketSession { Connection.IsClosed: true })
             {
                 break;
             }

--- a/src/Fluss.HotChocolate/BuilderExtensions.cs
+++ b/src/Fluss.HotChocolate/BuilderExtensions.cs
@@ -1,6 +1,9 @@
+using System.Runtime.CompilerServices;
 using HotChocolate.Execution.Configuration;
 using HotChocolate.Internal;
 using Microsoft.Extensions.DependencyInjection;
+
+[assembly: InternalsVisibleTo("Fluss.HotChocolate.IntegrationTest")]
 
 namespace Fluss.HotChocolate;
 


### PR DESCRIPTION
Currently, the check for whether a live-query is still connected is only performed after an EventListener related to it changes. This can lead to a lot of stale queries not being cleaned up because their value does not change.

This PR adds a 5 second loop to check whether a query is still connected outside of the publishing of new events leading to a much more stable cleanup of outstanding queries.